### PR TITLE
feat(ui): modernize diff view with toolbar and color-coded modes

### DIFF
--- a/crates/librefork-ui/src/widgets/commit_details.rs
+++ b/crates/librefork-ui/src/widgets/commit_details.rs
@@ -9,7 +9,12 @@ pub struct CommitDetails {
     header: gtk::Label,
     meta: gtk::Label,
     message: gtk::TextView,
-    diff: gtk::TextView,
+    toolbar: gtk::Box,
+    diff_stack: gtk::Stack,
+    inline_container: gtk::Box,
+    side_container: gtk::Box,
+    inline_button: gtk::ToggleButton,
+    side_button: gtk::ToggleButton,
 }
 
 impl CommitDetails {
@@ -34,22 +39,69 @@ impl CommitDetails {
         message.set_monospace(true);
         message.set_wrap_mode(gtk::WrapMode::WordChar);
 
-        let diff = gtk::TextView::new();
-        diff.set_editable(false);
-        diff.set_cursor_visible(false);
-        diff.set_monospace(true);
+        let toolbar = gtk::Box::new(Orientation::Horizontal, 4);
+        let inline_button = gtk::ToggleButton::builder()
+            .icon_name("view-list-symbolic")
+            .build();
+        let side_button = gtk::ToggleButton::builder()
+            .icon_name("view-dual-symbolic")
+            .group(&inline_button)
+            .build();
+        side_button.set_active(true);
+        toolbar.append(&inline_button);
+        toolbar.append(&side_button);
+
+        let diff_stack = gtk::Stack::new();
+        let inline_container = gtk::Box::new(Orientation::Vertical, 8);
+        let inline_sw = gtk::ScrolledWindow::builder()
+            .hexpand(true)
+            .vexpand(true)
+            .child(&inline_container)
+            .build();
+        let side_container = gtk::Box::new(Orientation::Vertical, 8);
+        let side_sw = gtk::ScrolledWindow::builder()
+            .hexpand(true)
+            .vexpand(true)
+            .child(&side_container)
+            .build();
+        diff_stack.add_named(&inline_sw, Some("inline"));
+        diff_stack.add_named(&side_sw, Some("side"));
+        diff_stack.set_visible_child_name("side");
+
+        {
+            let stack = diff_stack.clone();
+            side_button.connect_toggled(move |btn| {
+                if btn.is_active() {
+                    stack.set_visible_child_name("side");
+                }
+            });
+        }
+        {
+            let stack = diff_stack.clone();
+            inline_button.connect_toggled(move |btn| {
+                if btn.is_active() {
+                    stack.set_visible_child_name("inline");
+                }
+            });
+        }
 
         root.append(&header);
         root.append(&meta);
         root.append(&message);
-        root.append(&diff);
+        root.append(&toolbar);
+        root.append(&diff_stack);
 
         Self {
             root,
             header,
             meta,
             message,
-            diff,
+            toolbar,
+            diff_stack,
+            inline_container,
+            side_container,
+            inline_button,
+            side_button,
         }
     }
 
@@ -61,7 +113,12 @@ impl CommitDetails {
         self.header.set_text("");
         self.meta.set_text("");
         self.message.buffer().set_text("");
-        self.diff.buffer().set_text("");
+        while let Some(child) = self.inline_container.first_child() {
+            child.unparent();
+        }
+        while let Some(child) = self.side_container.first_child() {
+            child.unparent();
+        }
     }
 
     pub fn show_commit(&self, info: &CommitInfo, message: &str, diffs: &[FileDiff]) {
@@ -78,16 +135,107 @@ impl CommitDetails {
         ));
         self.message.buffer().set_text(message);
 
-        let mut text = String::new();
-        for file in diffs {
-            text.push_str(&format!("diff -- {}\n", file.path));
-            for line in &file.lines {
-                let left = line.left.as_deref().unwrap_or("");
-                let right = line.right.as_deref().unwrap_or("");
-                text.push_str(&format!("{:<40} | {}\n", left, right));
-            }
-            text.push('\n');
+        while let Some(child) = self.inline_container.first_child() {
+            child.unparent();
         }
-        self.diff.buffer().set_text(&text);
+        while let Some(child) = self.side_container.first_child() {
+            child.unparent();
+        }
+
+        for file in diffs {
+            let frame_inline = gtk::Frame::new(Some(&file.path));
+            let view_inline = gtk::TextView::new();
+            view_inline.set_editable(false);
+            view_inline.set_cursor_visible(false);
+            view_inline.set_monospace(true);
+            let buffer_i = view_inline.buffer();
+            let tag_add_i = buffer_i
+                .create_tag(Some("add"), &[("foreground", &"green")])
+                .unwrap();
+            let tag_del_i = buffer_i
+                .create_tag(Some("del"), &[("foreground", &"red")])
+                .unwrap();
+            let mut iter_i = buffer_i.end_iter();
+            for line in &file.lines {
+                match (line.left.as_ref(), line.right.as_ref()) {
+                    (Some(l), None) => {
+                        buffer_i.insert_with_tags(&mut iter_i, &format!("-{}\n", l), &[&tag_del_i]);
+                    }
+                    (None, Some(r)) => {
+                        buffer_i.insert_with_tags(&mut iter_i, &format!("+{}\n", r), &[&tag_add_i]);
+                    }
+                    (Some(l), Some(r)) => {
+                        if l == r {
+                            buffer_i.insert(&mut iter_i, &format!(" {}\n", l));
+                        } else {
+                            buffer_i.insert_with_tags(
+                                &mut iter_i,
+                                &format!("-{}\n", l),
+                                &[&tag_del_i],
+                            );
+                            buffer_i.insert_with_tags(
+                                &mut iter_i,
+                                &format!("+{}\n", r),
+                                &[&tag_add_i],
+                            );
+                        }
+                    }
+                    (None, None) => (),
+                }
+            }
+            frame_inline.set_child(Some(&view_inline));
+            self.inline_container.append(&frame_inline);
+
+            let frame_side = gtk::Frame::new(Some(&file.path));
+            let view_side = gtk::TextView::new();
+            view_side.set_editable(false);
+            view_side.set_cursor_visible(false);
+            view_side.set_monospace(true);
+            let buffer_s = view_side.buffer();
+            let tag_add_s = buffer_s
+                .create_tag(Some("add"), &[("foreground", &"green")])
+                .unwrap();
+            let tag_del_s = buffer_s
+                .create_tag(Some("del"), &[("foreground", &"red")])
+                .unwrap();
+            let mut iter_s = buffer_s.end_iter();
+            for line in &file.lines {
+                match (line.left.as_ref(), line.right.as_ref()) {
+                    (Some(l), None) => {
+                        buffer_s.insert_with_tags(
+                            &mut iter_s,
+                            &format!("{:<40}", l),
+                            &[&tag_del_s],
+                        );
+                        buffer_s.insert(&mut iter_s, " | \n");
+                    }
+                    (None, Some(r)) => {
+                        buffer_s.insert(&mut iter_s, &format!("{:<40}", ""));
+                        buffer_s.insert(&mut iter_s, " | ");
+                        buffer_s.insert_with_tags(&mut iter_s, &format!("{}\n", r), &[&tag_add_s]);
+                    }
+                    (Some(l), Some(r)) => {
+                        if l == r {
+                            buffer_s.insert(&mut iter_s, &format!("{:<40} | {}\n", l, r));
+                        } else {
+                            buffer_s.insert_with_tags(
+                                &mut iter_s,
+                                &format!("{:<40}", l),
+                                &[&tag_del_s],
+                            );
+                            buffer_s.insert(&mut iter_s, " | ");
+                            buffer_s.insert_with_tags(
+                                &mut iter_s,
+                                &format!("{}\n", r),
+                                &[&tag_add_s],
+                            );
+                        }
+                    }
+                    (None, None) => buffer_s.insert(&mut iter_s, "\n"),
+                }
+            }
+            frame_side.set_child(Some(&view_side));
+            self.side_container.append(&frame_side);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add toolbar with icon buttons to switch diff presentation
- show per-file diffs with inline or side-by-side views
- color additions in green and deletions in red

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ada93b067c832aae6bb399a50a1d6f