### PR TITLE
feat: add commit graph and tabbed commit details

### DIFF
--- a/crates/librefork-ui/src/app.rs
+++ b/crates/librefork-ui/src/app.rs
@@ -2,17 +2,24 @@ use adw::prelude::*;
 use adw::{Application, ApplicationWindow, HeaderBar, StyleManager};
 use gtk::Orientation;
 use gtk4 as gtk;
+use gtk4::{gdk::Display, CssProvider, STYLE_PROVIDER_PRIORITY_APPLICATION};
 use librefork_core::RepoHandle;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::widgets::{
-    commit_details::CommitDetails,
-    commit_list::CommitList,
-    side_panel::SidePanel,
+    commit_details::CommitDetails, commit_list::CommitList, side_panel::SidePanel,
 };
 
 pub fn build_ui(app: &Application) {
+    let provider = CssProvider::new();
+    provider.load_from_data(include_str!("styles.css"));
+    gtk::style_context_add_provider_for_display(
+        &Display::default().unwrap(),
+        &provider,
+        STYLE_PROVIDER_PRIORITY_APPLICATION,
+    );
+
     let window = ApplicationWindow::builder()
         .application(app)
         .title("LibreFork")
@@ -269,68 +276,68 @@ pub fn build_ui(app: &Application) {
     }
 
     {
-    let state_for_dialog = state.clone();
-    let window = window.clone();
-    let commit_list_c = commit_list.clone();
-    let details_c = details.clone();
-    let side_c_cloned = side_panel.clone(); // Clone du Rc ici
-    let branch_combo_c = branch_combo.clone();
-    let title_label_c = title_label.clone();
-    let load_more_c = load_more_button.clone();
-    let search_entry_c = search_entry.clone();
+        let state_for_dialog = state.clone();
+        let window = window.clone();
+        let commit_list_c = commit_list.clone();
+        let details_c = details.clone();
+        let side_c_cloned = side_panel.clone(); // Clone du Rc ici
+        let branch_combo_c = branch_combo.clone();
+        let title_label_c = title_label.clone();
+        let load_more_c = load_more_button.clone();
+        let search_entry_c = search_entry.clone();
 
-    // Holder pour garder le dialog vivant jusqu'à la réponse
-    let dialog_holder: Rc<RefCell<Option<gtk::FileChooserNative>>> =
-        Rc::new(RefCell::new(None));
+        // Holder pour garder le dialog vivant jusqu'à la réponse
+        let dialog_holder: Rc<RefCell<Option<gtk::FileChooserNative>>> =
+            Rc::new(RefCell::new(None));
 
-    open_button.connect_clicked(move |_| {
-        let dialog = gtk::FileChooserNative::builder()
-            .title("Ouvrir un dépôt Git")
-            .action(gtk::FileChooserAction::SelectFolder)
-            .transient_for(&window) // parent
-            .modal(true)
-            .build();
+        open_button.connect_clicked(move |_| {
+            let dialog = gtk::FileChooserNative::builder()
+                .title("Ouvrir un dépôt Git")
+                .action(gtk::FileChooserAction::SelectFolder)
+                .transient_for(&window) // parent
+                .modal(true)
+                .build();
 
-        // conservez une ref forte
-        *dialog_holder.borrow_mut() = Some(dialog.clone());
+            // conservez une ref forte
+            *dialog_holder.borrow_mut() = Some(dialog.clone());
 
-        dialog.connect_response({
-            let state_for_dialog_cb = state_for_dialog.clone();
-            let commit_list_c = commit_list_c.clone();
-            let details_c = details_c.clone();
-            let side_c_cloned = side_c_cloned.clone(); // Cloner ici
-            let branch_combo_c2 = branch_combo_c.clone();
-            let title_label_c2 = title_label_c.clone();
-            let load_more_c2 = load_more_c.clone();
-            let search_entry_c2 = search_entry_c.clone();
-            let holder = dialog_holder.clone();
+            dialog.connect_response({
+                let state_for_dialog_cb = state_for_dialog.clone();
+                let commit_list_c = commit_list_c.clone();
+                let details_c = details_c.clone();
+                let side_c_cloned = side_c_cloned.clone(); // Cloner ici
+                let branch_combo_c2 = branch_combo_c.clone();
+                let title_label_c2 = title_label_c.clone();
+                let load_more_c2 = load_more_c.clone();
+                let search_entry_c2 = search_entry_c.clone();
+                let holder = dialog_holder.clone();
 
-            move |dlg, resp| {
-                holder.borrow_mut().take();
+                move |dlg, resp| {
+                    holder.borrow_mut().take();
 
-                if resp == gtk::ResponseType::Accept {
-                    if let Some(file) = dlg.file() {
-                        if let Some(path) = file.path() {
-                            load_repo(
-                                path.to_string_lossy().as_ref(),
-                                &state_for_dialog_cb,
-                                &commit_list_c,
-                                &details_c,
-                                &side_c_cloned, // Utilisation du clone ici
-                                &branch_combo_c2,
-                                &title_label_c2,
-                                &load_more_c2,
-                                &search_entry_c2,
-                            );
+                    if resp == gtk::ResponseType::Accept {
+                        if let Some(file) = dlg.file() {
+                            if let Some(path) = file.path() {
+                                load_repo(
+                                    path.to_string_lossy().as_ref(),
+                                    &state_for_dialog_cb,
+                                    &commit_list_c,
+                                    &details_c,
+                                    &side_c_cloned, // Utilisation du clone ici
+                                    &branch_combo_c2,
+                                    &title_label_c2,
+                                    &load_more_c2,
+                                    &search_entry_c2,
+                                );
+                            }
                         }
                     }
                 }
-            }
-        });
+            });
 
-        dialog.show();
-    });
-}
+            dialog.show();
+        });
+    }
 
     // Load more commits
     {

--- a/crates/librefork-ui/src/styles.css
+++ b/crates/librefork-ui/src/styles.css
@@ -1,2 +1,9 @@
 .dim-label { opacity: 0.7; }
 .commit-warning { color: #f57900; }
+.tag-label {
+    background-color: #3584e4;
+    color: white;
+    border-radius: 4px;
+    padding: 0 4px;
+    font-size: 0.8em;
+}

--- a/crates/librefork-ui/src/widgets/commit_details.rs
+++ b/crates/librefork-ui/src/widgets/commit_details.rs
@@ -9,12 +9,9 @@ pub struct CommitDetails {
     header: gtk::Label,
     meta: gtk::Label,
     message: gtk::TextView,
-    toolbar: gtk::Box,
-    diff_stack: gtk::Stack,
     inline_container: gtk::Box,
     side_container: gtk::Box,
-    inline_button: gtk::ToggleButton,
-    side_button: gtk::ToggleButton,
+    filetree_container: gtk::Box,
 }
 
 impl CommitDetails {
@@ -25,20 +22,32 @@ impl CommitDetails {
         root.set_margin_start(12);
         root.set_margin_end(12);
 
+        let stack = gtk::Stack::new();
+        let switcher = gtk::StackSwitcher::new();
+        switcher.set_stack(Some(&stack));
+        root.append(&switcher);
+        root.append(&stack);
+
+        // Commit tab
+        let commit_box = gtk::Box::new(Orientation::Vertical, 8);
         let header = gtk::Label::new(None);
         header.add_css_class("title-3");
         header.set_xalign(0.0);
-
         let meta = gtk::Label::new(None);
         meta.add_css_class("dim-label");
         meta.set_xalign(0.0);
-
         let message = gtk::TextView::new();
         message.set_editable(false);
         message.set_cursor_visible(false);
         message.set_monospace(true);
         message.set_wrap_mode(gtk::WrapMode::WordChar);
+        commit_box.append(&header);
+        commit_box.append(&meta);
+        commit_box.append(&message);
+        stack.add_titled(&commit_box, Some("commit"), "Commit");
 
+        // Changes tab
+        let changes_box = gtk::Box::new(Orientation::Vertical, 8);
         let toolbar = gtk::Box::new(Orientation::Horizontal, 4);
         let inline_button = gtk::ToggleButton::builder()
             .icon_name("view-list-symbolic")
@@ -67,7 +76,6 @@ impl CommitDetails {
         diff_stack.add_named(&inline_sw, Some("inline"));
         diff_stack.add_named(&side_sw, Some("side"));
         diff_stack.set_visible_child_name("side");
-
         {
             let stack = diff_stack.clone();
             side_button.connect_toggled(move |btn| {
@@ -84,24 +92,27 @@ impl CommitDetails {
                 }
             });
         }
+        changes_box.append(&toolbar);
+        changes_box.append(&diff_stack);
+        stack.add_titled(&changes_box, Some("changes"), "Changes");
 
-        root.append(&header);
-        root.append(&meta);
-        root.append(&message);
-        root.append(&toolbar);
-        root.append(&diff_stack);
+        // Filetree tab
+        let filetree_container = gtk::Box::new(Orientation::Vertical, 4);
+        let filetree_sw = gtk::ScrolledWindow::builder()
+            .hexpand(true)
+            .vexpand(true)
+            .child(&filetree_container)
+            .build();
+        stack.add_titled(&filetree_sw, Some("filetree"), "Filetree");
 
         Self {
             root,
             header,
             meta,
             message,
-            toolbar,
-            diff_stack,
             inline_container,
             side_container,
-            inline_button,
-            side_button,
+            filetree_container,
         }
     }
 
@@ -117,6 +128,9 @@ impl CommitDetails {
             child.unparent();
         }
         while let Some(child) = self.side_container.first_child() {
+            child.unparent();
+        }
+        while let Some(child) = self.filetree_container.first_child() {
             child.unparent();
         }
     }
@@ -139,6 +153,9 @@ impl CommitDetails {
             child.unparent();
         }
         while let Some(child) = self.side_container.first_child() {
+            child.unparent();
+        }
+        while let Some(child) = self.filetree_container.first_child() {
             child.unparent();
         }
 
@@ -237,6 +254,10 @@ impl CommitDetails {
             }
             frame_side.set_child(Some(&view_side));
             self.side_container.append(&frame_side);
+
+            let file_label = gtk::Label::new(Some(&file.path));
+            file_label.set_xalign(0.0);
+            self.filetree_container.append(&file_label);
         }
     }
 }

--- a/crates/librefork-ui/src/widgets/commit_list.rs
+++ b/crates/librefork-ui/src/widgets/commit_list.rs
@@ -1,7 +1,7 @@
 use adw::prelude::*;
 use gtk::Orientation;
 use gtk4 as gtk;
-use gtk4::pango;
+use gtk4::{cairo, pango};
 use librefork_core::CommitInfo;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -61,9 +61,20 @@ impl CommitList {
         row_box.set_margin_end(8);
 
         let top = gtk::Box::new(Orientation::Horizontal, 8);
-        let graph = gtk::Label::new(Some("●"));
-        graph.add_css_class("monospace");
-        graph.set_xalign(0.0);
+        let graph = gtk::DrawingArea::new();
+        graph.set_content_width(12);
+        graph.set_content_height(24);
+        graph.set_draw_func(|_, cr: &cairo::Context, w, h| {
+            let w = w as f64;
+            let h = h as f64;
+            cr.set_source_rgb(0.5, 0.5, 0.5);
+            cr.set_line_width(2.0);
+            cr.move_to(w / 2.0, 0.0);
+            cr.line_to(w / 2.0, h);
+            cr.stroke().ok();
+            cr.arc(w / 2.0, h / 2.0, 3.0, 0.0, std::f64::consts::PI * 2.0);
+            cr.fill().ok();
+        });
 
         let hash = gtk::Label::new(Some(&format!("{}", c.short_id)));
         hash.add_css_class("monospace");
@@ -82,14 +93,17 @@ impl CommitList {
         top.append(&hash);
         top.append(&summary);
 
-        let refs = if c.refs.is_empty() {
-            String::new()
-        } else {
-            format!(" • refs: {}", c.refs.join(", "))
-        };
+        let tag_box = gtk::Box::new(Orientation::Horizontal, 4);
+        for r in &c.refs {
+            let tag = gtk::Label::new(Some(r));
+            tag.add_css_class("tag-label");
+            tag_box.append(&tag);
+        }
+        top.append(&tag_box);
+
         let bottom = gtk::Label::new(Some(&format!(
-            "{} <{}> • {} • {} parents{}",
-            c.author, c.email, c.time, c.parents, refs
+            "{} <{}> • {} • {} parents",
+            c.author, c.email, c.time, c.parents
         )));
         bottom.add_css_class("dim-label");
         bottom.set_xalign(0.0);
@@ -141,7 +155,6 @@ impl CommitList {
                         || c.short_id.contains(&q)
                         || c.oid.contains(&q)
                 })
-
                 .cloned()
                 .collect();
             self.reload_list(&filtered);


### PR DESCRIPTION
## Summary
- display commit graph with tag badges
- show commit details in tabbed view with file tree
- load custom styles for tag labels

## Testing
- `cargo check -p librefork-ui`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68adb8e6724c832abcfdcdc0de027b51