### PR TITLE
feat(ui): show colored commit graph with details

### DIFF
--- a/crates/librefork-ui/src/app.rs
+++ b/crates/librefork-ui/src/app.rs
@@ -72,17 +72,17 @@ pub fn build_ui(app: &Application) {
 
     // Main layout
     let paned = gtk::Paned::builder()
-        .orientation(Orientation::Horizontal)
+        .orientation(Orientation::Vertical)
         .start_child(&gtk::Label::new(None))
         .end_child(&gtk::Label::new(None))
         .wide_handle(true)
         .build();
 
-    let left_scrolled = gtk::ScrolledWindow::builder()
+    let commit_scrolled = gtk::ScrolledWindow::builder()
         .hexpand(true)
         .vexpand(true)
         .build();
-    let right = gtk::ScrolledWindow::builder()
+    let details_scrolled = gtk::ScrolledWindow::builder()
         .hexpand(true)
         .vexpand(true)
         .build();
@@ -91,20 +91,20 @@ pub fn build_ui(app: &Application) {
     let details = CommitDetails::new();
     let side_panel = SidePanel::new();
 
-    left_scrolled.set_child(Some(commit_list.widget()));
-    right.set_child(Some(details.widget()));
+    commit_scrolled.set_child(Some(commit_list.widget()));
+    details_scrolled.set_child(Some(details.widget()));
 
     let load_more_button = gtk::Button::with_label("Charger plus");
     let search_entry = gtk::SearchEntry::new();
     search_entry.set_placeholder_text(Some("Rechercher"));
-    let left_box = gtk::Box::new(Orientation::Vertical, 0);
-    left_box.append(&search_entry);
-    left_box.append(&left_scrolled);
-    left_box.append(&load_more_button);
+    let top_box = gtk::Box::new(Orientation::Vertical, 0);
+    top_box.append(&search_entry);
+    top_box.append(&commit_scrolled);
+    top_box.append(&load_more_button);
 
-    paned.set_start_child(Some(&left_box));
-    paned.set_end_child(Some(&right));
-    paned.set_position(420);
+    paned.set_start_child(Some(&top_box));
+    paned.set_end_child(Some(&details_scrolled));
+    paned.set_position(300);
 
     let outer = gtk::Paned::builder()
         .orientation(Orientation::Horizontal)

--- a/crates/librefork-ui/src/widgets/commit_list.rs
+++ b/crates/librefork-ui/src/widgets/commit_list.rs
@@ -22,6 +22,17 @@ struct GraphRowData {
     lane_count: usize,
 }
 
+const LANE_COLORS: [(f64, f64, f64); 8] = [
+    (0.89, 0.10, 0.11),
+    (0.22, 0.49, 0.72),
+    (0.20, 0.63, 0.17),
+    (0.60, 0.31, 0.64),
+    (1.00, 0.50, 0.00),
+    (0.65, 0.34, 0.16),
+    (0.97, 0.51, 0.75),
+    (0.13, 0.70, 0.67),
+];
+
 impl CommitList {
     pub fn new() -> Self {
         let root = gtk::Box::new(Orientation::Vertical, 0);
@@ -62,34 +73,41 @@ impl CommitList {
     fn row_from_commit(c: &CommitInfo, g: &GraphRowData) -> gtk::ListBoxRow {
         let row = gtk::ListBoxRow::new();
 
-        let row_box = gtk::Box::new(Orientation::Vertical, 4);
-        row_box.set_margin_top(8);
-        row_box.set_margin_bottom(8);
+        let row_box = gtk::Box::new(Orientation::Horizontal, 8);
+        row_box.set_margin_top(4);
+        row_box.set_margin_bottom(4);
         row_box.set_margin_start(8);
         row_box.set_margin_end(8);
 
-        let top = gtk::Box::new(Orientation::Horizontal, 8);
         let graph = gtk::DrawingArea::new();
         graph.set_content_width((g.lane_count as i32) * 12);
         graph.set_content_height(24);
         let gd = g.clone();
+        let colors = LANE_COLORS;
         graph.set_draw_func(move |_, cr: &cairo::Context, _w, h| {
             let h = h as f64;
             let lane_width = 12.0;
             let center = |lane: usize| lane_width / 2.0 + lane as f64 * lane_width;
-            cr.set_source_rgb(0.5, 0.5, 0.5);
             cr.set_line_width(2.0);
 
             for (lane, oid_opt) in gd.active_before.iter().enumerate() {
                 if oid_opt.is_some() {
+                    let (r, g, b) = colors[lane % colors.len()];
+                    cr.set_source_rgb(r, g, b);
                     let x = center(lane);
                     cr.move_to(x, 0.0);
-                    cr.line_to(x, h);
+                    if lane == gd.node_lane {
+                        cr.line_to(x, h / 2.0);
+                    } else {
+                        cr.line_to(x, h);
+                    }
                     cr.stroke().ok();
                 }
             }
 
             for &p_lane in &gd.parent_lanes {
+                let (r, g, b) = colors[p_lane % colors.len()];
+                cr.set_source_rgb(r, g, b);
                 let x0 = center(gd.node_lane);
                 let y0 = h / 2.0;
                 let x1 = center(p_lane);
@@ -103,48 +121,56 @@ impl CommitList {
                 cr.stroke().ok();
             }
 
+            let (r, g, b) = colors[gd.node_lane % colors.len()];
+            cr.set_source_rgb(r, g, b);
             let x = center(gd.node_lane);
             cr.arc(x, h / 2.0, 3.0, 0.0, std::f64::consts::PI * 2.0);
             cr.fill().ok();
         });
 
-        let hash = gtk::Label::new(Some(&format!("{}", c.short_id)));
-        hash.add_css_class("monospace");
-        hash.set_xalign(0.0);
-
+        let message_box = gtk::Box::new(Orientation::Horizontal, 4);
+        message_box.set_hexpand(true);
         let summary = gtk::Label::new(Some(&c.summary));
         summary.set_xalign(0.0);
         summary.set_ellipsize(pango::EllipsizeMode::End);
         summary.set_hexpand(true);
+        summary.set_valign(gtk::Align::Center);
         let lowered = c.summary.to_lowercase();
         if lowered.contains("crash") {
             summary.add_css_class("commit-warning");
         }
-
-        top.append(&graph);
-        top.append(&hash);
-        top.append(&summary);
+        message_box.append(&summary);
 
         let tag_box = gtk::Box::new(Orientation::Horizontal, 4);
+        tag_box.set_valign(gtk::Align::Center);
         for r in &c.refs {
             let tag = gtk::Label::new(Some(r));
             tag.add_css_class("tag-label");
             tag_box.append(&tag);
         }
-        top.append(&tag_box);
+        message_box.append(&tag_box);
 
-        let bottom = gtk::Label::new(Some(&format!(
-            "{} <{}> • {} • {} parents",
-            c.author,
-            c.email,
-            c.time,
-            c.parents.len()
-        )));
-        bottom.add_css_class("dim-label");
-        bottom.set_xalign(0.0);
+        let author = gtk::Label::new(Some(&c.author));
+        author.add_css_class("dim-label");
+        author.set_xalign(0.0);
+        author.set_valign(gtk::Align::Center);
 
-        row_box.append(&top);
-        row_box.append(&bottom);
+        let hash = gtk::Label::new(Some(&c.short_id));
+        hash.add_css_class("monospace");
+        hash.add_css_class("dim-label");
+        hash.set_xalign(0.0);
+        hash.set_valign(gtk::Align::Center);
+
+        let date = gtk::Label::new(Some(&c.time));
+        date.add_css_class("dim-label");
+        date.set_xalign(0.0);
+        date.set_valign(gtk::Align::Center);
+
+        row_box.append(&graph);
+        row_box.append(&message_box);
+        row_box.append(&author);
+        row_box.append(&hash);
+        row_box.append(&date);
 
         row.set_child(Some(&row_box));
         row.set_widget_name(&c.oid);


### PR DESCRIPTION
## Summary
- color commit graph lanes and nodes
- display commit message, author, hash, and date in columns
- show commit details below list via vertical pane

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68adc27b1bd8832abd18de5813f12e6e