### PR TITLE
Add favorites menu and extend repo tree

### DIFF
--- a/crates/librefork-core/src/lib.rs
+++ b/crates/librefork-core/src/lib.rs
@@ -112,6 +112,42 @@ impl RepoHandle {
         Ok(remotes)
     }
 
+    pub fn list_tags(&self) -> Result<Vec<String>> {
+        let mut tags = Vec::new();
+        self.repo.tag_foreach(|_, name| {
+            if let Ok(name_str) = std::str::from_utf8(name) {
+                tags.push(name_str.to_string());
+            }
+            true
+        })?;
+        Ok(tags)
+    }
+
+    pub fn list_stashes(&self) -> Result<Vec<String>> {
+        let mut stashes = Vec::new();
+        let mut repo = Repository::open(&self.path)?;
+        repo.stash_foreach(|i, name, _oid| {
+            let label = if name.is_empty() {
+                format!("stash@{{{}}}", i)
+            } else {
+                name.to_string()
+            };
+            stashes.push(label);
+            true
+        })?;
+        Ok(stashes)
+    }
+
+    pub fn list_submodules(&self) -> Result<Vec<String>> {
+        let mut subs = Vec::new();
+        for sm in self.repo.submodules()? {
+            if let Some(name) = sm.name() {
+                subs.push(name.to_string());
+            }
+        }
+        Ok(subs)
+    }
+
     pub fn list_commits_paginated(&self, skip: usize, max: usize) -> Result<Vec<CommitInfo>> {
         let mut revwalk = self.repo.revwalk()?;
         revwalk.set_sorting(Sort::TOPOLOGICAL | Sort::TIME)?;

--- a/crates/librefork-ui/src/app.rs
+++ b/crates/librefork-ui/src/app.rs
@@ -10,6 +10,8 @@ use std::rc::Rc;
 use crate::widgets::{
     commit_details::CommitDetails, commit_list::CommitList, side_panel::SidePanel,
 };
+use crate::starred::StarredItem;
+use std::collections::HashSet;
 
 pub fn build_ui(app: &Application) {
     let provider = CssProvider::new();
@@ -87,9 +89,16 @@ pub fn build_ui(app: &Application) {
         .vexpand(true)
         .build();
 
-    let commit_list = CommitList::new();
+    let starred: Rc<RefCell<HashSet<StarredItem>>> = Rc::new(RefCell::new(HashSet::new()));
+    let commit_list = CommitList::new(starred.clone());
     let details = CommitDetails::new();
-    let side_panel = SidePanel::new();
+    let side_panel = SidePanel::new(starred.clone());
+    {
+        let side_c = side_panel.clone();
+        commit_list.on_star_changed(move || {
+            side_c.reload();
+        });
+    }
 
     commit_scrolled.set_child(Some(commit_list.widget()));
     details_scrolled.set_child(Some(details.widget()));
@@ -175,6 +184,15 @@ pub fn build_ui(app: &Application) {
                 }
                 if let Ok(remotes) = repo.list_remotes() {
                     side.load_remotes(&remotes);
+                }
+                if let Ok(tags) = repo.list_tags() {
+                    side.load_tags(&tags);
+                }
+                if let Ok(stashes) = repo.list_stashes() {
+                    side.load_stashes(&stashes);
+                }
+                if let Ok(subs) = repo.list_submodules() {
+                    side.load_submodules(&subs);
                 }
 
                 let mut st = state.borrow_mut();

--- a/crates/librefork-ui/src/main.rs
+++ b/crates/librefork-ui/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod widgets;
+mod starred;
 
 use adw::prelude::*;
 use adw::Application;

--- a/crates/librefork-ui/src/starred.rs
+++ b/crates/librefork-ui/src/starred.rs
@@ -1,0 +1,5 @@
+#[derive(Hash, Eq, PartialEq, Clone)]
+pub enum StarredItem {
+    Branch(String),
+    Commit(String),
+}

--- a/crates/librefork-ui/src/widgets/commit_list.rs
+++ b/crates/librefork-ui/src/widgets/commit_list.rs
@@ -4,6 +4,7 @@ use gtk::Orientation;
 use gtk4 as gtk;
 use gtk4::{cairo, pango};
 use librefork_core::CommitInfo;
+use crate::starred::StarredItem;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -14,7 +15,8 @@ pub struct CommitList {
     list: gtk::ListBox,
     commits: Rc<RefCell<Vec<CommitInfo>>>,
     on_select: Rc<RefCell<Option<Box<dyn Fn(&str)>>>>,
-    starred: Rc<RefCell<HashSet<String>>>,
+    starred: Rc<RefCell<HashSet<StarredItem>>>,
+    on_star_changed: Rc<RefCell<Option<Box<dyn Fn()>>>>,
 }
 
 #[derive(Clone)]
@@ -37,7 +39,7 @@ const LANE_COLORS: [(f64, f64, f64); 8] = [
 ];
 
 impl CommitList {
-    pub fn new() -> Self {
+    pub fn new(starred: Rc<RefCell<HashSet<StarredItem>>>) -> Self {
         let root = gtk::Box::new(Orientation::Vertical, 0);
         root.set_hexpand(true);
         root.set_vexpand(true);
@@ -49,7 +51,7 @@ impl CommitList {
 
         let on_select: Rc<RefCell<Option<Box<dyn Fn(&str)>>>> = Rc::new(RefCell::new(None));
         let commits: Rc<RefCell<Vec<CommitInfo>>> = Rc::new(RefCell::new(Vec::new()));
-        let starred: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
+        let on_star_changed: Rc<RefCell<Option<Box<dyn Fn()>>>> = Rc::new(RefCell::new(None));
 
         let cb = on_select.clone();
         list.connect_row_selected(move |_, row| {
@@ -67,6 +69,7 @@ impl CommitList {
             commits,
             on_select,
             starred,
+            on_star_changed,
         }
     }
 
@@ -74,10 +77,15 @@ impl CommitList {
         self.root.upcast_ref()
     }
 
+    pub fn on_star_changed(&self, cb: impl Fn() + 'static) {
+        *self.on_star_changed.borrow_mut() = Some(Box::new(cb));
+    }
+
     fn row_from_commit(
         c: &CommitInfo,
         g: &GraphRowData,
-        starred: Rc<RefCell<HashSet<String>>>,
+        starred: Rc<RefCell<HashSet<StarredItem>>>,
+        on_star_changed: Rc<RefCell<Option<Box<dyn Fn()>>>>,
     ) -> gtk::ListBoxRow {
         let row = gtk::ListBoxRow::new();
         row.set_height_request(24);
@@ -93,7 +101,10 @@ impl CommitList {
 
         let star_label = gtk::Label::new(Some("☆"));
         star_label.set_width_chars(1);
-        if starred.borrow().contains(&c.oid) {
+        if starred
+            .borrow()
+            .contains(&StarredItem::Commit(c.oid.clone()))
+        {
             star_label.set_text("★");
         }
 
@@ -209,16 +220,47 @@ impl CommitList {
         let oid = c.oid.clone();
         let star_label_c = star_label.clone();
         let click = gtk::GestureClick::new();
-        click.connect_pressed(move |g, _, _, _| {
+        let row_c = row.clone();
+        click.connect_pressed(move |g, _, x, y| {
             if g.current_button() == 3 {
-                let mut st = starred.borrow_mut();
-                if st.contains(&oid) {
-                    st.remove(&oid);
-                    star_label_c.set_text("☆");
+                let item = StarredItem::Commit(oid.clone());
+                let already = starred.borrow().contains(&item);
+                let label = if already {
+                    "Retirer des favoris"
                 } else {
-                    st.insert(oid.clone());
-                    star_label_c.set_text("★");
-                }
+                    "Ajouter aux favoris"
+                };
+                let pop = gtk::Popover::new();
+                let bx = gtk::Box::new(Orientation::Vertical, 0);
+                let starred_c = starred.clone();
+                let star_label_c2 = star_label_c.clone();
+                let pop_c = pop.clone();
+                let on_star_c = on_star_changed.clone();
+                let btn = gtk::Button::with_label(label);
+                btn.connect_clicked(move |_| {
+                    let mut st = starred_c.borrow_mut();
+                    if already {
+                        st.remove(&item);
+                        star_label_c2.set_text("☆");
+                    } else {
+                        st.insert(item.clone());
+                        star_label_c2.set_text("★");
+                    }
+                    if let Some(cb) = &*on_star_c.borrow() {
+                        cb();
+                    }
+                    pop_c.popdown();
+                });
+                bx.append(&btn);
+                pop.set_child(Some(&bx));
+                pop.set_pointing_to(Some(&gtk::gdk::Rectangle::new(
+                    x as i32,
+                    y as i32,
+                    1,
+                    1,
+                )));
+                pop.set_parent(&row_c);
+                pop.popup();
             }
         });
         row.add_controller(click);
@@ -274,7 +316,12 @@ impl CommitList {
         }
         let graphs = Self::compute_graph(commits);
         for (c, g) in commits.iter().zip(graphs.iter()) {
-            let row = Self::row_from_commit(c, g, self.starred.clone());
+            let row = Self::row_from_commit(
+                c,
+                g,
+                self.starred.clone(),
+                self.on_star_changed.clone(),
+            );
             self.list.append(&row);
         }
     }

--- a/crates/librefork-ui/src/widgets/side_panel.rs
+++ b/crates/librefork-ui/src/widgets/side_panel.rs
@@ -1,10 +1,12 @@
-use adw::prelude::*;
+use gtk::prelude::*;
 use gtk::Orientation;
 use gtk4 as gtk;
 use librefork_core::BranchStatus;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
+use crate::starred::StarredItem;
+use gtk::gdk;
 
 #[derive(Clone)]
 pub struct SidePanel {
@@ -14,11 +16,14 @@ pub struct SidePanel {
     store: gtk::TreeStore,
     branches: Rc<RefCell<Vec<BranchStatus>>>,
     remotes: Rc<RefCell<Vec<String>>>,
-    starred: Rc<RefCell<HashSet<String>>>,
+    tags: Rc<RefCell<Vec<String>>>,
+    stashes: Rc<RefCell<Vec<String>>>,
+    submodules: Rc<RefCell<Vec<String>>>,
+    starred: Rc<RefCell<HashSet<StarredItem>>>,
 }
 
 impl SidePanel {
-    pub fn new() -> Self {
+    pub fn new(starred: Rc<RefCell<HashSet<StarredItem>>>) -> Self {
         let root = gtk::Box::new(Orientation::Vertical, 4);
         root.set_hexpand(false);
         root.set_vexpand(true);
@@ -27,7 +32,11 @@ impl SidePanel {
         search.set_placeholder_text(Some("Rechercher une branche"));
         root.append(&search);
 
-        let store = gtk::TreeStore::new(&[String::static_type(), String::static_type()]);
+        let store = gtk::TreeStore::new(&[
+            String::static_type(),
+            String::static_type(),
+            String::static_type(),
+        ]);
         let tree = gtk::TreeView::with_model(&store);
         tree.set_headers_visible(false);
 
@@ -47,7 +56,9 @@ impl SidePanel {
 
         let branches: Rc<RefCell<Vec<BranchStatus>>> = Rc::new(RefCell::new(Vec::new()));
         let remotes: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
-        let starred: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
+        let tags: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let stashes: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let submodules: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
 
         let panel = Self {
             root,
@@ -56,6 +67,9 @@ impl SidePanel {
             store: store.clone(),
             branches: branches.clone(),
             remotes: remotes.clone(),
+            tags: tags.clone(),
+            stashes: stashes.clone(),
+            submodules: submodules.clone(),
             starred: starred.clone(),
         };
 
@@ -70,23 +84,53 @@ impl SidePanel {
         let tree_c = tree.clone();
         let store_c = store.clone();
         let starred_c = starred.clone();
+        let panel_c = panel.clone();
         click.connect_pressed(move |g, _, x, y| {
             if g.current_button() == 3 {
                 if let Some((Some(path), _col, _x, _y)) = tree_c.path_at_pos(x as i32, y as i32) {
                     if let Some(iter) = store_c.iter(&path) {
                         if store_c.iter_parent(&iter).is_some() {
-                            if let Ok(name) = store_c
-                                .get_value(&iter, 1)
-                                .get::<String>()
-                            {
-                                let mut st = starred_c.borrow_mut();
-                                if st.contains(&name) {
-                                    st.remove(&name);
-                                    store_c.set(&iter, &[(0u32, &"☆"), (1u32, &name)]);
+                            if let (Ok(name), Ok(kind)) = (
+                                store_c.get_value(&iter, 1).get::<String>(),
+                                store_c.get_value(&iter, 2).get::<String>(),
+                            ) {
+                                let item = match kind.as_str() {
+                                    "branch" => StarredItem::Branch(name.clone()),
+                                    "commit" => StarredItem::Commit(name.clone()),
+                                    _ => return,
+                                };
+                                let already = starred_c.borrow().contains(&item);
+                                let label = if already {
+                                    "Retirer des favoris"
                                 } else {
-                                    st.insert(name.clone());
-                                    store_c.set(&iter, &[(0u32, &"★"), (1u32, &name)]);
-                                }
+                                    "Ajouter aux favoris"
+                                };
+                                let pop = gtk::Popover::new();
+                                let bx = gtk::Box::new(Orientation::Vertical, 0);
+                                let starred_c2 = starred_c.clone();
+                                let pop_c = pop.clone();
+                                let panel_c2 = panel_c.clone();
+                                let btn = gtk::Button::with_label(label);
+                                btn.connect_clicked(move |_| {
+                                    let mut st = starred_c2.borrow_mut();
+                                    if already {
+                                        st.remove(&item);
+                                    } else {
+                                        st.insert(item.clone());
+                                    }
+                                    panel_c2.reload();
+                                    pop_c.popdown();
+                                });
+                                bx.append(&btn);
+                                pop.set_child(Some(&bx));
+                                pop.set_pointing_to(Some(&gdk::Rectangle::new(
+                                    x as i32,
+                                    y as i32,
+                                    1,
+                                    1,
+                                )));
+                                pop.set_parent(&tree_c);
+                                pop.popup();
                             }
                         }
                     }
@@ -102,28 +146,82 @@ impl SidePanel {
         self.root.upcast_ref()
     }
 
-    fn reload(&self) {
+    pub fn reload(&self) {
         self.store.clear();
+        let starred_root = self.store.append(None);
+        self.store
+            .set(&starred_root, &[(0, &""), (1, &"Starred"), (2, &"root")]);
         let branches_root = self.store.append(None);
-        self.store.set(&branches_root, &[(0, &""), (1, &"Branches")]);
+        self.store
+            .set(&branches_root, &[(0, &""), (1, &"Branches"), (2, &"root")]);
         let remotes_root = self.store.append(None);
-        self.store.set(&remotes_root, &[(0, &""), (1, &"Remotes")]);
+        self.store
+            .set(&remotes_root, &[(0, &""), (1, &"Remotes"), (2, &"root")]);
+        let tags_root = self.store.append(None);
+        self.store
+            .set(&tags_root, &[(0, &""), (1, &"Tags"), (2, &"root")]);
+        let stashes_root = self.store.append(None);
+        self.store
+            .set(&stashes_root, &[(0, &""), (1, &"Stashes"), (2, &"root")]);
+        let submodules_root = self.store.append(None);
+        self.store
+            .set(&submodules_root, &[(0, &""), (1, &"Submodules"), (2, &"root")]);
+
         let q = self.search.text().to_string().to_lowercase();
         let stars = self.starred.borrow();
+        for item in stars.iter() {
+            match item {
+                StarredItem::Branch(name) => {
+                    if name.to_lowercase().contains(&q) {
+                        let iter = self.store.append(Some(&starred_root));
+                        self.store
+                            .set(&iter, &[(0, &"★"), (1, name), (2, &"branch")]);
+                    }
+                }
+                StarredItem::Commit(oid) => {
+                    let short = oid.chars().take(7).collect::<String>();
+                    if short.to_lowercase().contains(&q) {
+                        let iter = self.store.append(Some(&starred_root));
+                        self.store.set(&iter, &[(0, &"★"), (1, &short), (2, &"commit")]);
+                    }
+                }
+            }
+        }
+
         for b in self
             .branches
             .borrow()
             .iter()
             .filter(|b| b.name.to_lowercase().contains(&q))
         {
-            let star = if stars.contains(&b.name) { "★" } else { "☆" };
+            let star = if stars.contains(&StarredItem::Branch(b.name.clone())) {
+                "★"
+            } else {
+                "☆"
+            };
             let label = format!("{} (+{}, -{})", b.name, b.ahead, b.behind);
             let iter = self.store.append(Some(&branches_root));
-            self.store.set(&iter, &[(0, &star), (1, &label)]);
+            self.store.set(&iter, &[(0, &star), (1, &label), (2, &"branch")]);
         }
         for r in self.remotes.borrow().iter() {
             let iter = self.store.append(Some(&remotes_root));
-            self.store.set(&iter, &[(0, &""), (1, r)]);
+            self.store
+                .set(&iter, &[(0, &""), (1, r), (2, &"remote")]);
+        }
+        for t in self.tags.borrow().iter() {
+            let iter = self.store.append(Some(&tags_root));
+            self.store
+                .set(&iter, &[(0, &""), (1, t), (2, &"tag")]);
+        }
+        for s in self.stashes.borrow().iter() {
+            let iter = self.store.append(Some(&stashes_root));
+            self.store
+                .set(&iter, &[(0, &""), (1, s), (2, &"stash")]);
+        }
+        for m in self.submodules.borrow().iter() {
+            let iter = self.store.append(Some(&submodules_root));
+            self.store
+                .set(&iter, &[(0, &""), (1, m), (2, &"submodule")]);
         }
     }
 
@@ -139,6 +237,30 @@ impl SidePanel {
         let mut v = self.remotes.borrow_mut();
         v.clear();
         v.extend_from_slice(remotes);
+        drop(v);
+        self.reload();
+    }
+
+    pub fn load_tags(&self, tags: &[String]) {
+        let mut v = self.tags.borrow_mut();
+        v.clear();
+        v.extend_from_slice(tags);
+        drop(v);
+        self.reload();
+    }
+
+    pub fn load_stashes(&self, stashes: &[String]) {
+        let mut v = self.stashes.borrow_mut();
+        v.clear();
+        v.extend_from_slice(stashes);
+        drop(v);
+        self.reload();
+    }
+
+    pub fn load_submodules(&self, subs: &[String]) {
+        let mut v = self.submodules.borrow_mut();
+        v.clear();
+        v.extend_from_slice(subs);
         drop(v);
         self.reload();
     }


### PR DESCRIPTION
## Summary
- add context menu to commit and branch lists for starring
- show Starred, Tags, Stashes and Submodules in side panel
- expose repo helpers to list tags, stashes and submodules

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aeb048c2fc832a877d6a0c73f5ef6b