### PR TITLE
Release mutable borrow before reloading side panel

### DIFF
--- a/crates/librefork-ui/src/widgets/side_panel.rs
+++ b/crates/librefork-ui/src/widgets/side_panel.rs
@@ -113,11 +113,16 @@ impl SidePanel {
                             let panel_c2 = panel_c.clone();
                             let btn = gtk::Button::with_label(label);
                             btn.connect_clicked(move |_| {
-                                let mut st = starred_c2.borrow_mut();
-                                if already {
-                                    st.remove(&item);
-                                } else {
-                                    st.insert(item.clone());
+                                {
+                                    // Ensure the mutable borrow of `starred_c2` is dropped before
+                                    // reloading the panel, otherwise `reload` would attempt to
+                                    // borrow the same `RefCell` again and panic.
+                                    let mut st = starred_c2.borrow_mut();
+                                    if already {
+                                        st.remove(&item);
+                                    } else {
+                                        st.insert(item.clone());
+                                    }
                                 }
                                 panel_c2.reload();
                                 pop_c.popdown();


### PR DESCRIPTION
## Summary
- avoid RefCell borrow panic by dropping starred list borrow before reloading

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb5e6716c832aa1d077353d1a09b5