### PR TITLE
Persist starred branches and commits across sessions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,5 @@ adw  = { version = "0.6", package = "libadwaita" }
 glib = "0.20"
 gio  = "0.20"
 once_cell = "1"
+rusqlite = { version = "0.31", features = ["bundled"] }
+dirs = "5"

--- a/crates/librefork-ui/Cargo.toml
+++ b/crates/librefork-ui/Cargo.toml
@@ -13,3 +13,5 @@ gio = { workspace = true }
 once_cell = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
+rusqlite = { workspace = true }
+dirs = { workspace = true }

--- a/crates/librefork-ui/src/app.rs
+++ b/crates/librefork-ui/src/app.rs
@@ -7,10 +7,10 @@ use librefork_core::RepoHandle;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use crate::starred::{StarDb, StarredItem};
 use crate::widgets::{
     commit_details::CommitDetails, commit_list::CommitList, side_panel::SidePanel,
 };
-use crate::starred::StarredItem;
 use std::collections::HashSet;
 
 pub fn build_ui(app: &Application) {
@@ -89,16 +89,12 @@ pub fn build_ui(app: &Application) {
         .vexpand(true)
         .build();
 
+    let star_db = Rc::new(StarDb::new().expect("failed to init star db"));
     let starred: Rc<RefCell<HashSet<StarredItem>>> = Rc::new(RefCell::new(HashSet::new()));
+    let prev_stars: Rc<RefCell<HashSet<StarredItem>>> = Rc::new(RefCell::new(HashSet::new()));
     let commit_list = CommitList::new(starred.clone());
     let details = CommitDetails::new();
     let side_panel = SidePanel::new(starred.clone());
-    {
-        let side_c = side_panel.clone();
-        commit_list.on_star_changed(move || {
-            side_c.reload();
-        });
-    }
 
     commit_scrolled.set_child(Some(commit_list.widget()));
     details_scrolled.set_child(Some(details.widget()));
@@ -145,6 +141,31 @@ pub fn build_ui(app: &Application) {
     let state = Rc::new(RefCell::new(State::default()));
     const PAGE_SIZE: usize = 100;
 
+    let commit_list_c = commit_list.clone();
+    let side_c = side_panel.clone();
+    let state_c = state.clone();
+    let starred_c = starred.clone();
+    let prev_c = prev_stars.clone();
+    let star_db_c = star_db.clone();
+    let search_entry_c = search_entry.clone();
+    let star_cb = move || {
+        if let Some(repo) = state_c.borrow().repo_path.clone() {
+            let new_set = starred_c.borrow();
+            let prev_set = prev_c.borrow();
+            for item in new_set.difference(&prev_set) {
+                let _ = star_db_c.add(&repo, item);
+            }
+            for item in prev_set.difference(&new_set) {
+                let _ = star_db_c.remove(&repo, item);
+            }
+        }
+        *prev_c.borrow_mut() = starred_c.borrow().clone();
+        side_c.reload();
+        commit_list_c.filter(&search_entry_c.text());
+    };
+    commit_list.on_star_changed(star_cb.clone());
+    side_panel.on_star_changed(star_cb);
+
     fn load_repo(
         path: &str,
         state: &Rc<RefCell<State>>,
@@ -155,9 +176,19 @@ pub fn build_ui(app: &Application) {
         title_label: &gtk::Label,
         load_more: &gtk::Button,
         search_entry: &gtk::SearchEntry,
+        starred: &Rc<RefCell<HashSet<StarredItem>>>,
+        prev_stars: &Rc<RefCell<HashSet<StarredItem>>>,
+        star_db: &StarDb,
     ) {
         match RepoHandle::open(path) {
             Ok(repo) => {
+                if let Ok(stars) = star_db.load(path) {
+                    let mut st = starred.borrow_mut();
+                    st.clear();
+                    st.extend(stars);
+                    *prev_stars.borrow_mut() = st.clone();
+                }
+
                 if let Ok(head) = repo.head() {
                     if let Some(name) = head {
                         title_label.set_text(&format!("LibreFork - {}", name));
@@ -222,6 +253,9 @@ pub fn build_ui(app: &Application) {
         let title_label_c = title_label.clone();
         let load_more_c = load_more_button.clone();
         let search_entry_c = search_entry.clone();
+        let starred_c = starred.clone();
+        let prev_c = prev_stars.clone();
+        let star_db_c = star_db.clone();
         refresh_button.connect_clicked(move |_| {
             let path_opt = { state.borrow().repo_path.clone() };
             if let Some(path) = path_opt {
@@ -235,6 +269,9 @@ pub fn build_ui(app: &Application) {
                     &title_label_c,
                     &load_more_c,
                     &search_entry_c,
+                    &starred_c,
+                    &prev_c,
+                    &star_db_c,
                 );
             }
         });
@@ -303,6 +340,9 @@ pub fn build_ui(app: &Application) {
         let title_label_c = title_label.clone();
         let load_more_c = load_more_button.clone();
         let search_entry_c = search_entry.clone();
+        let starred_c = starred.clone();
+        let prev_c = prev_stars.clone();
+        let star_db_c = star_db.clone();
 
         // Holder pour garder le dialog vivant jusqu'à la réponse
         let dialog_holder: Rc<RefCell<Option<gtk::FileChooserNative>>> =
@@ -328,6 +368,9 @@ pub fn build_ui(app: &Application) {
                 let title_label_c2 = title_label_c.clone();
                 let load_more_c2 = load_more_c.clone();
                 let search_entry_c2 = search_entry_c.clone();
+                let starred_c2 = starred_c.clone();
+                let prev_c2 = prev_c.clone();
+                let star_db_c2 = star_db_c.clone();
                 let holder = dialog_holder.clone();
 
                 move |dlg, resp| {
@@ -346,6 +389,9 @@ pub fn build_ui(app: &Application) {
                                     &title_label_c2,
                                     &load_more_c2,
                                     &search_entry_c2,
+                                    &starred_c2,
+                                    &prev_c2,
+                                    &star_db_c2,
                                 );
                             }
                         }
@@ -412,6 +458,9 @@ pub fn build_ui(app: &Application) {
             &title_label,
             &load_more_button,
             &search_entry,
+            &starred,
+            &prev_stars,
+            &star_db,
         );
     }
 

--- a/crates/librefork-ui/src/starred.rs
+++ b/crates/librefork-ui/src/starred.rs
@@ -1,5 +1,79 @@
+use anyhow::Result;
+use rusqlite::{params, Connection};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
 #[derive(Hash, Eq, PartialEq, Clone)]
 pub enum StarredItem {
     Branch(String),
     Commit(String),
+}
+
+pub struct StarDb {
+    conn: Connection,
+}
+
+impl StarDb {
+    pub fn new() -> Result<Self> {
+        let mut path = dirs::data_dir().unwrap_or_else(|| PathBuf::from("."));
+        path.push("librefork");
+        std::fs::create_dir_all(&path)?;
+        path.push("stars.db");
+        let conn = Connection::open(path)?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS stars (
+                repo TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                name TEXT NOT NULL,
+                PRIMARY KEY(repo, kind, name)
+            )",
+            [],
+        )?;
+        Ok(Self { conn })
+    }
+
+    pub fn load(&self, repo: &str) -> Result<HashSet<StarredItem>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT kind, name FROM stars WHERE repo = ?1")?;
+        let iter = stmt.query_map([repo], |row| {
+            let kind: String = row.get(0)?;
+            let name: String = row.get(1)?;
+            let item = if kind == "branch" {
+                StarredItem::Branch(name)
+            } else {
+                StarredItem::Commit(name)
+            };
+            Ok(item)
+        })?;
+        let mut set = HashSet::new();
+        for r in iter {
+            set.insert(r?);
+        }
+        Ok(set)
+    }
+
+    pub fn add(&self, repo: &str, item: &StarredItem) -> Result<()> {
+        let (kind, name) = match item {
+            StarredItem::Branch(n) => ("branch", n),
+            StarredItem::Commit(n) => ("commit", n),
+        };
+        self.conn.execute(
+            "INSERT OR IGNORE INTO stars (repo, kind, name) VALUES (?1, ?2, ?3)",
+            params![repo, kind, name],
+        )?;
+        Ok(())
+    }
+
+    pub fn remove(&self, repo: &str, item: &StarredItem) -> Result<()> {
+        let (kind, name) = match item {
+            StarredItem::Branch(n) => ("branch", n),
+            StarredItem::Commit(n) => ("commit", n),
+        };
+        self.conn.execute(
+            "DELETE FROM stars WHERE repo = ?1 AND kind = ?2 AND name = ?3",
+            params![repo, kind, name],
+        )?;
+        Ok(())
+    }
 }

--- a/crates/librefork-ui/src/widgets/side_panel.rs
+++ b/crates/librefork-ui/src/widgets/side_panel.rs
@@ -20,6 +20,7 @@ pub struct SidePanel {
     stashes: Rc<RefCell<Vec<String>>>,
     submodules: Rc<RefCell<Vec<String>>>,
     starred: Rc<RefCell<HashSet<StarredItem>>>,
+    on_star_changed: Rc<RefCell<Option<Box<dyn Fn()>>>>,
 }
 
 impl SidePanel {
@@ -69,6 +70,8 @@ impl SidePanel {
         let stashes: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
         let submodules: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
 
+        let on_star_changed: Rc<RefCell<Option<Box<dyn Fn()>>>> = Rc::new(RefCell::new(None));
+
         let panel = Self {
             root,
             search: search.clone(),
@@ -80,6 +83,7 @@ impl SidePanel {
             stashes: stashes.clone(),
             submodules: submodules.clone(),
             starred: starred.clone(),
+            on_star_changed: on_star_changed.clone(),
         };
 
         search.connect_search_changed({
@@ -94,7 +98,7 @@ impl SidePanel {
         let tree_c = tree.clone();
         let store_c = store.clone();
         let starred_c = starred.clone();
-        let panel_c = panel.clone();
+        let on_star_c = on_star_changed.clone();
         click.connect_pressed(move |_, _, x, y| {
             if let Some((Some(path), _col, _x, _y)) = tree_c.path_at_pos(x as i32, y as i32) {
                 if let Some(iter) = store_c.iter(&path) {
@@ -118,13 +122,10 @@ impl SidePanel {
                             let bx = gtk::Box::new(Orientation::Vertical, 0);
                             let starred_c2 = starred_c.clone();
                             let pop_c = pop.clone();
-                            let panel_c2 = panel_c.clone();
+                            let on_star_c2 = on_star_c.clone();
                             let btn = gtk::Button::with_label(label);
                             btn.connect_clicked(move |_| {
                                 {
-                                    // Ensure the mutable borrow of `starred_c2` is dropped before
-                                    // reloading the panel, otherwise `reload` would attempt to
-                                    // borrow the same `RefCell` again and panic.
                                     let mut st = starred_c2.borrow_mut();
                                     if already {
                                         st.remove(&item);
@@ -132,7 +133,9 @@ impl SidePanel {
                                         st.insert(item.clone());
                                     }
                                 }
-                                panel_c2.reload();
+                                if let Some(cb) = &*on_star_c2.borrow() {
+                                    cb();
+                                }
                                 pop_c.popdown();
                             });
                             bx.append(&btn);
@@ -150,6 +153,10 @@ impl SidePanel {
         tree.add_controller(click);
 
         panel
+    }
+
+    pub fn on_star_changed(&self, cb: impl Fn() + 'static) {
+        *self.on_star_changed.borrow_mut() = Some(Box::new(cb));
     }
 
     pub fn widget(&self) -> &gtk::Widget {


### PR DESCRIPTION
## Summary
- store starred branches and commits in a SQLite database
- reload stars when opening a repository and keep them updated on change
- expose star change callbacks from side panel to notify the app

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aebd707c60832aa99bd7d472bf4d25